### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @DeepSourceCorp/language-l2
+* deepak@deepsource.io swarnim@deepsource.io tushar@deepsource.io

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* deepak@deepsource.io swarnim@deepsource.io tushar@deepsource.io
+* deepak@deepsource.io swarnim@deepsource.io tushar@deepsource.io anto@deepsource.io


### PR DESCRIPTION
Putting `language-l2` as codeowner will email everyone in the team everytime a PR is made. So don't do that.