### PR TITLE
Use newer ubuntu

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
 FROM swift:5.8.1-jammy as swift-format-builder
 ADD . /toolbox
 WORKDIR /toolbox
-RUN swift build -c release -Xswiftc -static-executable
+RUN swift build -c release --static-swift-stdlib

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM swift:5.8.1-focal as swift-format-builder
+FROM swift:5.8.1-jammy as swift-format-builder
 ADD . /toolbox
 WORKDIR /toolbox
 RUN swift build -c release -Xswiftc -static-executable


### PR DESCRIPTION
Uses `jammy` to fix CVEs, and remove `-Xswiftc -static-executable` because it seems to be buggy now.

To make the new binary work, bumblebee ships with `libc` and `libstdc++`, refer [this PR](https://github.com/DeepSourceCorp/bumblebee/pull/197)